### PR TITLE
Fix undefined reference to pcre_config on Ubuntu 23.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bin/csvawk: $(CSV_AWK_FILES) Makefile bin/
 
 csvgrep: bin/csvgrep
 bin/csvgrep: $(CSV_GREP_FILES) Makefile bin/
-	$(CC) -o $@ $(LinkFlags) `pcre-config --libs` $(CFLAGS) `pcre-config --cflags` $(CSV_GREP_FILES) 
+	$(CC) -o $@ $(LinkFlags) $(CFLAGS) `pcre-config --cflags` $(CSV_GREP_FILES) `pcre-config --libs`
 
 bin/csvtokenizercounts: $(CSV_TOK_TEST_COUNT_FILES) Makefile bin/
 	$(CC) -o $@ $(LinkFlags) $(CFLAGS) $(CSV_TOK_TEST_COUNT_FILES)


### PR DESCRIPTION
Fix https://github.com/DavyLandman/csvtools/issues/18

Before this commit build fails with:

```
cc -o bin/csvcut  -std=gnu99 -Wall -pedantic -Wextra -DBUFFER_SIZE=1048576
-fno-strict-aliasing -O3 -DNDEBUG -D_GNU_SOURCE src/csvcut.c
src/csv_tokenizer.c
cc -o bin/csvgrep  `pcre-config --libs` -std=gnu99 -Wall -pedantic -Wextra
-DBUFFER_SIZE=1048576  -fno-strict-aliasing -O3 -DNDEBUG -D_GNU_SOURCE
`pcre-config --cflags` src/csvgrep.c src/csv_tokenizer.c
/usr/bin/ld: /tmp/ccjk4lIW.o: warning: relocation against `pcre_free' in
read-only section `.text.startup'
/usr/bin/ld: /tmp/ccjk4lIW.o: in function `output_cells':
csvgrep.c:(.text+0x2dd): undefined reference to `pcre_exec'
/usr/bin/ld: /tmp/ccjk4lIW.o: in function `main':
csvgrep.c:(.text.startup+0x23c): undefined reference to `pcre_config'
/usr/bin/ld: csvgrep.c:(.text.startup+0x53a): undefined reference to
`pcre_compile'
/usr/bin/ld: csvgrep.c:(.text.startup+0x588): undefined reference to
`pcre_study'
/usr/bin/ld: csvgrep.c:(.text.startup+0x8b6): undefined reference to
`pcre_free_study'
/usr/bin/ld: csvgrep.c:(.text.startup+0x8cb): undefined reference to
`pcre_free'
/usr/bin/ld: csvgrep.c:(.text.startup+0x91d): undefined reference to
`pcre_free'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
make: *** [Makefile:75: bin/csvgrep] Error 1
```