### PR TITLE
Fix `calloc()` argument order

### DIFF
--- a/src/csv_tokenizer.c
+++ b/src/csv_tokenizer.c
@@ -70,7 +70,7 @@ static void print_current_line(const char* restrict current_char,const char* res
 
     // copy string such that we can put a \0 at the end
     size_t line_length = end-start;
-    char* printable_string = calloc(sizeof(char), line_length + 1);
+    char* printable_string = calloc(line_length + 1, sizeof(char));
     memcpy(printable_string, start, line_length);
     printable_string[line_length] = '\0';
     fprintf(stderr, "Current line: %s\n", printable_string);

--- a/src/csvcut.c
+++ b/src/csvcut.c
@@ -91,7 +91,7 @@ static void debug_cells(size_t total) {
             LOG_V("Cell %zu : \n", (size_t)(current_cell - _cells));
         }
         else {
-            char* s = calloc(sizeof(char), current_cell->length + 1);
+            char* s = calloc(current_cell->length + 1, sizeof(char));
             s[current_cell->length] = '\0';
             memcpy(s, current_cell->start, current_cell->length);
             LOG_V("Cell %zu : %s\n", (size_t)(current_cell - _cells), s);
@@ -289,7 +289,7 @@ static void finish_config(size_t cells_found) {
         config.newline_length = 2;
     }
 
-    config.keep = calloc(sizeof(bool), config.column_count);
+    config.keep = calloc(config.column_count, sizeof(bool));
     for (int c = 0; c < config.column_count; c++) {
         config.keep[c] =  false;
     }

--- a/src/csvgrep.c
+++ b/src/csvgrep.c
@@ -125,7 +125,7 @@ static void debug_cells(size_t total) {
             LOG_V("Cell %zu : \n", (size_t)(current_cell - _cells));
         }
         else {
-            char* s = calloc(sizeof(char), current_cell->length + 1);
+            char* s = calloc(current_cell->length + 1, sizeof(char));
             s[current_cell->length] = '\0';
             memcpy(s, current_cell->start, current_cell->length);
             LOG_V("Cell %zu : %s\n", (size_t)(current_cell - _cells), s);
@@ -266,9 +266,9 @@ static size_t finish_config(size_t cells_found) {
         fwrite(config.newline, sizeof(char), config.newline_length, stdout);
     }
 
-    bool* used = calloc(sizeof(bool), half_config.n_patterns);
+    bool* used = calloc(half_config.n_patterns, sizeof(bool));
     memset(used, 0, sizeof(bool) * half_config.n_patterns);
-    config.patterns = calloc(sizeof(Regex),config.column_count);
+    config.patterns = calloc(config.column_count, sizeof(Regex));
     memset(config.patterns, 0, sizeof(Regex) * config.column_count);
     for (int c = 0; c < config.column_count; c++) {
         const char* column = _cells[c].start;


### PR DESCRIPTION
Fixes a few build warnings, though I don’t think they cause any issues.

----

(In particular, AFAICT this doesn’t fix issue #20.)